### PR TITLE
Make SolutionBuilder thread-safe for background analysis

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="3.3.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.5.0-release-20230105-01" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageVersion Include="System.Collections.Immutable" Version="7.0.0" />

--- a/Nerdbank.Algorithms.sln
+++ b/Nerdbank.Algorithms.sln
@@ -1,20 +1,35 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29622.13
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33312.295
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nerdbank.Algorithms", "src\Nerdbank.Algorithms\Nerdbank.Algorithms.csproj", "{7D0A3E71-C7A5-4465-BCA1-0B9533936D29}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nerdbank.AlgorithmsTest", "test\Nerdbank.Algorithms.Tests\Nerdbank.Algorithms.Tests.csproj", "{B4474D3C-8D00-46CE-9616-A7663967E65C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nerdbank.Algorithms.Tests", "test\Nerdbank.Algorithms.Tests\Nerdbank.Algorithms.Tests.csproj", "{B4474D3C-8D00-46CE-9616-A7663967E65C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D5505154-F37C-47AD-A881-0F985B28D2E0}"
 	ProjectSection(SolutionItems) = preProject
-		..\.editorconfig = ..\.editorconfig
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
-		..\global.json = ..\global.json
-		..\nuget.config = ..\nuget.config
+		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
+		nuget.config = nuget.config
 		stylecop.json = stylecop.json
-		..\version.json = ..\version.json
+		version.json = version.json
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C6ED3062-7B2E-433F-9680-3587B57ECCAB}"
+	ProjectSection(SolutionItems) = preProject
+		src\.editorconfig = src\.editorconfig
+		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.targets = src\Directory.Build.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{C3D0E574-A9AB-4013-B734-E801E139A1CB}"
+	ProjectSection(SolutionItems) = preProject
+		test\.editorconfig = test\.editorconfig
+		test\Directory.Build.props = test\Directory.Build.props
+		test\Directory.Build.targets = test\Directory.Build.targets
 	EndProjectSection
 EndProject
 Global
@@ -34,6 +49,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{7D0A3E71-C7A5-4465-BCA1-0B9533936D29} = {C6ED3062-7B2E-433F-9680-3587B57ECCAB}
+		{B4474D3C-8D00-46CE-9616-A7663967E65C} = {C3D0E574-A9AB-4013-B734-E801E139A1CB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {25187ACA-E88C-4517-96DA-971C5610752A}

--- a/src/Nerdbank.Algorithms/Nerdbank.Algorithms.csproj
+++ b/src/Nerdbank.Algorithms/Nerdbank.Algorithms.csproj
@@ -6,10 +6,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
     <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="BannedSymbols.txt" />
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="NodeConstraintSelection\Strings.Designer.cs">

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/Configuration`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/Configuration`1.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
+
+namespace Nerdbank.Algorithms.NodeConstraintSelection;
+
+/// <summary>
+/// Configuration for a node constraint selection problem space.
+/// </summary>
+/// <typeparam name="TNodeState">The type of nodes in the problem space.</typeparam>
+public class Configuration<TNodeState>
+	where TNodeState : unmanaged
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Configuration{TNodeState}"/> class.
+	/// </summary>
+	/// <param name="nodes">The nodes in the problem/solution.</param>
+	/// <param name="resolvedNodeStates">An array of allowed values for each node.</param>
+	/// <exception cref="ArgumentNullException">Thrown if <paramref name="nodes"/> is <see langword="null"/>.</exception>
+	/// <exception cref="ArgumentException">Thrown if <paramref name="nodes"/> is empty or contains duplicates.</exception>
+	public Configuration(ImmutableArray<object> nodes, ImmutableArray<TNodeState> resolvedNodeStates)
+	{
+		if (nodes.IsDefault)
+		{
+			throw new ArgumentNullException(nameof(nodes));
+		}
+
+		if (nodes.IsEmpty)
+		{
+			throw new ArgumentException(Strings.NonEmptyArrayRequired, nameof(nodes));
+		}
+
+		if (resolvedNodeStates.IsDefaultOrEmpty)
+		{
+			throw new ArgumentException(Strings.NonEmptyArrayRequired, nameof(resolvedNodeStates));
+		}
+
+		if (resolvedNodeStates.Length < 2)
+		{
+			throw new ArgumentException(Strings.AtLeastTwoNodeStatesRequired, nameof(resolvedNodeStates));
+		}
+
+		this.Nodes = nodes;
+		this.ResolvedNodeStates = resolvedNodeStates;
+		this.Index = CreateNodeIndex(nodes);
+		this.ScenarioPool = new ScenarioPool<TNodeState>(this);
+	}
+
+	/// <summary>
+	/// Gets the nodes in the problem space.
+	/// </summary>
+	public ImmutableArray<object> Nodes { get; }
+
+	/// <summary>
+	/// Gets a map of nodes to their index within <see cref="Nodes"/>.
+	/// </summary>
+	public ReadOnlyDictionary<object, int> Index { get; }
+
+	/// <summary>
+	/// Gets the values a resolved node may take.
+	/// </summary>
+	public ImmutableArray<TNodeState> ResolvedNodeStates { get; }
+
+	/// <summary>
+	/// Gets the scenario pool to use.
+	/// </summary>
+	internal ScenarioPool<TNodeState> ScenarioPool { get; }
+
+	/// <summary>
+	/// Creates a map of nodes to the index in a list.
+	/// </summary>
+	/// <param name="nodes">The list of nodes.</param>
+	/// <returns>The map of nodes to where they are found in the <paramref name="nodes"/> list.</returns>
+	private static ReadOnlyDictionary<object, int> CreateNodeIndex(ImmutableArray<object> nodes)
+	{
+		var lookup = new Dictionary<object, int>(nodes.Length);
+		for (int i = 0; i < nodes.Length; i++)
+		{
+			lookup.Add(nodes[i], i);
+		}
+
+		return new ReadOnlyDictionary<object, int>(lookup);
+	}
+}

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/IConstraint`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/IConstraint`1.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
+
 namespace Nerdbank.Algorithms.NodeConstraintSelection;
 
 /// <summary>
@@ -15,9 +17,9 @@ public interface IConstraint<TNodeState> : IEquatable<IConstraint<TNodeState>?>
 	where TNodeState : unmanaged
 {
 	/// <summary>
-	/// Gets the set of indexes to nodes that are involved in the constraint.
+	/// Gets the set of nodes that are involved in the constraint.
 	/// </summary>
-	IReadOnlyCollection<object> Nodes { get; }
+	ImmutableArray<object> Nodes { get; }
 
 	/// <summary>
 	/// Gets the state of the constraint with respect to a given scenario.

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/ScenarioPool`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/ScenarioPool`1.cs
@@ -18,25 +18,22 @@ internal class ScenarioPool<TNodeState>
 	where TNodeState : unmanaged
 {
 	private readonly ConcurrentBag<Scenario<TNodeState>> bag = new();
-	private readonly ImmutableArray<object> nodes;
-	private readonly ReadOnlyDictionary<object, int> nodeIndex;
+	private readonly Configuration<TNodeState> configuration;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ScenarioPool{TNodeState}"/> class.
 	/// </summary>
-	/// <param name="nodes">The nodes in the problem/solution.</param>
-	/// <param name="nodeIndex">A map of nodes to their index into <paramref name="nodes"/>.</param>
-	internal ScenarioPool(ImmutableArray<object> nodes, ReadOnlyDictionary<object, int> nodeIndex)
+	/// <param name="configuration">The problem space configuration.</param>
+	internal ScenarioPool(Configuration<TNodeState> configuration)
 	{
-		this.nodes = nodes;
-		this.nodeIndex = nodeIndex;
+		this.configuration = configuration;
 	}
 
 	/// <summary>
 	/// Acquires a recycled or new <see cref="Scenario{TNodeState}"/> instance.
 	/// </summary>
 	/// <returns>An instance of <see cref="Scenario{TNodeState}"/>.</returns>
-	internal Scenario<TNodeState> Take() => this.bag.TryTake(out Scenario<TNodeState>? scenario) ? scenario : new(this.nodes, this.nodeIndex);
+	internal Scenario<TNodeState> Take() => this.bag.TryTake(out Scenario<TNodeState>? scenario) ? scenario : new(this.configuration);
 
 	/// <summary>
 	/// Returns a <see cref="Scenario{TNodeState}"/> for recycling.

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/ScenarioPool`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/ScenarioPool`1.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
+
 namespace Nerdbank.Algorithms.NodeConstraintSelection;
 
 /// <summary>
@@ -14,7 +16,7 @@ internal class ScenarioPool<TNodeState>
 	where TNodeState : unmanaged
 {
 	private readonly Stack<Scenario<TNodeState>> bag = new();
-	private readonly IReadOnlyList<object> nodes;
+	private readonly ImmutableArray<object> nodes;
 	private readonly IReadOnlyDictionary<object, int> nodeIndex;
 
 	/// <summary>
@@ -22,7 +24,7 @@ internal class ScenarioPool<TNodeState>
 	/// </summary>
 	/// <param name="nodes">The nodes in the problem/solution.</param>
 	/// <param name="nodeIndex">A map of nodes to their index into <paramref name="nodes"/>.</param>
-	internal ScenarioPool(IReadOnlyList<object> nodes, IReadOnlyDictionary<object, int> nodeIndex)
+	internal ScenarioPool(ImmutableArray<object> nodes, IReadOnlyDictionary<object, int> nodeIndex)
 	{
 		this.nodes = nodes;
 		this.nodeIndex = nodeIndex;

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/ScenarioPool`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/ScenarioPool`1.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 
 namespace Nerdbank.Algorithms.NodeConstraintSelection;
 
@@ -17,14 +18,14 @@ internal class ScenarioPool<TNodeState>
 {
 	private readonly Stack<Scenario<TNodeState>> bag = new();
 	private readonly ImmutableArray<object> nodes;
-	private readonly IReadOnlyDictionary<object, int> nodeIndex;
+	private readonly ReadOnlyDictionary<object, int> nodeIndex;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ScenarioPool{TNodeState}"/> class.
 	/// </summary>
 	/// <param name="nodes">The nodes in the problem/solution.</param>
 	/// <param name="nodeIndex">A map of nodes to their index into <paramref name="nodes"/>.</param>
-	internal ScenarioPool(ImmutableArray<object> nodes, IReadOnlyDictionary<object, int> nodeIndex)
+	internal ScenarioPool(ImmutableArray<object> nodes, ReadOnlyDictionary<object, int> nodeIndex)
 	{
 		this.nodes = nodes;
 		this.nodeIndex = nodeIndex;

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
@@ -66,7 +66,7 @@ public sealed class Scenario<TNodeState>
 	internal ImmutableArray<IConstraint<TNodeState>> Constraints => this.constraints;
 
 	/// <summary>
-	/// Gets a value that changes each time a node selection is changed.
+	/// Gets a value that changes each time a node selection or constraint is changed.
 	/// </summary>
 	internal int Version { get; private set; }
 

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
@@ -24,7 +24,7 @@ public sealed class Scenario<TNodeState>
 	/// <summary>
 	/// The nodes in the solution.
 	/// </summary>
-	private readonly IReadOnlyList<object> nodes;
+	private readonly ImmutableArray<object> nodes;
 
 	/// <summary>
 	/// A map of nodes to their index into <see cref="nodes"/>.
@@ -48,14 +48,14 @@ public sealed class Scenario<TNodeState>
 	/// <remarks>
 	/// This constructor is designed for unit testing constraints.
 	/// </remarks>
-	public Scenario(IReadOnlyList<object> nodes)
+	public Scenario(ImmutableArray<object> nodes)
 	{
-		if (nodes is null)
+		if (nodes.IsDefault)
 		{
 			throw new ArgumentNullException(nameof(nodes));
 		}
 
-		this.selectionState = new TNodeState?[nodes.Count];
+		this.selectionState = new TNodeState?[nodes.Length];
 		this.nodes = nodes;
 		this.nodeIndex = CreateNodeIndex(nodes);
 		this.constraintsPerNode = nodes.Select(n => ImmutableArray.Create<IConstraint<TNodeState>>()).ToImmutableArray();
@@ -66,9 +66,9 @@ public sealed class Scenario<TNodeState>
 	/// </summary>
 	/// <param name="nodes">The nodes in the problem/solution.</param>
 	/// <param name="nodeIndex">A map of nodes to their index into <paramref name="nodes"/>.</param>
-	internal Scenario(IReadOnlyList<object> nodes, IReadOnlyDictionary<object, int> nodeIndex)
+	internal Scenario(ImmutableArray<object> nodes, IReadOnlyDictionary<object, int> nodeIndex)
 	{
-		this.selectionState = new TNodeState?[nodes.Count];
+		this.selectionState = new TNodeState?[nodes.Length];
 		this.nodes = nodes;
 		this.nodeIndex = nodeIndex;
 		this.constraintsPerNode = nodes.Select(n => ImmutableArray.Create<IConstraint<TNodeState>>()).ToImmutableArray();
@@ -77,7 +77,7 @@ public sealed class Scenario<TNodeState>
 	/// <summary>
 	/// Gets the number of nodes in the problem/solution.
 	/// </summary>
-	public int NodeCount => this.nodes.Count;
+	public int NodeCount => this.nodes.Length;
 
 	/// <summary>
 	/// Gets a list of the states of every node.
@@ -156,10 +156,10 @@ public sealed class Scenario<TNodeState>
 	/// </summary>
 	/// <param name="nodes">The list of nodes.</param>
 	/// <returns>The map of nodes to where they are found in the <paramref name="nodes"/> list.</returns>
-	internal static IReadOnlyDictionary<object, int> CreateNodeIndex(IReadOnlyList<object> nodes)
+	internal static IReadOnlyDictionary<object, int> CreateNodeIndex(ImmutableArray<object> nodes)
 	{
 		var lookup = new Dictionary<object, int>();
-		for (int i = 0; i < nodes.Count; i++)
+		for (int i = 0; i < nodes.Length; i++)
 		{
 			lookup.Add(nodes[i], i);
 		}
@@ -192,7 +192,7 @@ public sealed class Scenario<TNodeState>
 	/// <exception cref="BadConstraintException{TNodeState}">Thrown when the <paramref name="constraint"/> has an empty set of <see cref="IConstraint{TNodeState}.Nodes"/>.</exception>
 	internal void AddConstraint(IConstraint<TNodeState> constraint)
 	{
-		if (constraint.Nodes.Count == 0)
+		if (constraint.Nodes.IsEmpty)
 		{
 			throw new BadConstraintException<TNodeState>(constraint, Strings.ConstraintForEmptySetOfNodes);
 		}

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
@@ -29,7 +29,7 @@ public sealed class Scenario<TNodeState>
 	/// <summary>
 	/// A map of nodes to their index into <see cref="nodes"/>.
 	/// </summary>
-	private readonly IReadOnlyDictionary<object, int> nodeIndex;
+	private readonly ReadOnlyDictionary<object, int> nodeIndex;
 
 	/// <summary>
 	/// The constraints that describe the solution.
@@ -66,7 +66,7 @@ public sealed class Scenario<TNodeState>
 	/// </summary>
 	/// <param name="nodes">The nodes in the problem/solution.</param>
 	/// <param name="nodeIndex">A map of nodes to their index into <paramref name="nodes"/>.</param>
-	internal Scenario(ImmutableArray<object> nodes, IReadOnlyDictionary<object, int> nodeIndex)
+	internal Scenario(ImmutableArray<object> nodes, ReadOnlyDictionary<object, int> nodeIndex)
 	{
 		this.selectionState = new TNodeState?[nodes.Length];
 		this.nodes = nodes;
@@ -156,7 +156,7 @@ public sealed class Scenario<TNodeState>
 	/// </summary>
 	/// <param name="nodes">The list of nodes.</param>
 	/// <returns>The map of nodes to where they are found in the <paramref name="nodes"/> list.</returns>
-	internal static IReadOnlyDictionary<object, int> CreateNodeIndex(ImmutableArray<object> nodes)
+	internal static ReadOnlyDictionary<object, int> CreateNodeIndex(ImmutableArray<object> nodes)
 	{
 		var lookup = new Dictionary<object, int>();
 		for (int i = 0; i < nodes.Length; i++)

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/Scenario`1.cs
@@ -12,6 +12,7 @@ namespace Nerdbank.Algorithms.NodeConstraintSelection;
 /// <typeparam name="TNodeState">The type of value that a node may be set to.</typeparam>
 /// <remarks>
 /// Thread safety: Instance members on this class are not thread safe.
+/// All state on an instance is either immutable or exclusive to this instance.
 /// </remarks>
 public sealed class Scenario<TNodeState>
 	where TNodeState : unmanaged
@@ -49,16 +50,8 @@ public sealed class Scenario<TNodeState>
 	/// This constructor is designed for unit testing constraints.
 	/// </remarks>
 	public Scenario(ImmutableArray<object> nodes)
+		: this(nodes, CreateNodeIndex(nodes))
 	{
-		if (nodes.IsDefault)
-		{
-			throw new ArgumentNullException(nameof(nodes));
-		}
-
-		this.selectionState = new TNodeState?[nodes.Length];
-		this.nodes = nodes;
-		this.nodeIndex = CreateNodeIndex(nodes);
-		this.constraintsPerNode = nodes.Select(n => ImmutableArray.Create<IConstraint<TNodeState>>()).ToImmutableArray();
 	}
 
 	/// <summary>
@@ -158,7 +151,7 @@ public sealed class Scenario<TNodeState>
 	/// <returns>The map of nodes to where they are found in the <paramref name="nodes"/> list.</returns>
 	internal static ReadOnlyDictionary<object, int> CreateNodeIndex(ImmutableArray<object> nodes)
 	{
-		var lookup = new Dictionary<object, int>();
+		var lookup = new Dictionary<object, int>(nodes.Length);
 		for (int i = 0; i < nodes.Length; i++)
 		{
 			lookup.Add(nodes[i], i);

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/SelectionCountConstraint.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/SelectionCountConstraint.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Immutable;
 using System.Globalization;
 
 namespace Nerdbank.Algorithms.NodeConstraintSelection;
@@ -16,7 +17,7 @@ public class SelectionCountConstraint : IConstraint<bool>
 	/// <summary>
 	/// Backing field for the <see cref="Nodes"/> property.
 	/// </summary>
-	private readonly object[] nodes;
+	private readonly ImmutableArray<object> nodes;
 
 	/// <summary>
 	/// The indexes for each node in <see cref="nodes"/>.
@@ -32,9 +33,9 @@ public class SelectionCountConstraint : IConstraint<bool>
 	/// <param name="minSelected">The minimum number of nodes that may be selected.</param>
 	/// <param name="maxSelected">The maximum number of nodes that may be selected. If this exceeds the count of <paramref name="nodes"/>, the value will be adjusted to equal the total count.</param>
 	/// <param name="nodes">The nodes involved in the constraint.</param>
-	public SelectionCountConstraint(IEnumerable<object> nodes, int minSelected, int maxSelected)
+	public SelectionCountConstraint(ImmutableArray<object> nodes, int minSelected, int maxSelected)
 	{
-		if (nodes is null)
+		if (nodes.IsDefault)
 		{
 			throw new ArgumentNullException(nameof(nodes));
 		}
@@ -54,7 +55,7 @@ public class SelectionCountConstraint : IConstraint<bool>
 			throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Strings.Arg1GreaterThanArg2Required, nameof(maxSelected), nameof(minSelected)));
 		}
 
-		this.nodes = nodes as object[] ?? nodes.ToArray();
+		this.nodes = nodes;
 
 		if (this.nodes.Length == 0)
 		{
@@ -68,7 +69,7 @@ public class SelectionCountConstraint : IConstraint<bool>
 	}
 
 	/// <inheritdoc/>
-	public IReadOnlyCollection<object> Nodes => this.nodes;
+	public ImmutableArray<object> Nodes => this.nodes;
 
 	/// <summary>
 	/// Gets the minimum number of nodes that must be selected.
@@ -86,7 +87,10 @@ public class SelectionCountConstraint : IConstraint<bool>
 	/// <param name="nodes">The nodes that the constraint applies to.</param>
 	/// <param name="maximum">The maximum nodes that must be selected in the solution.</param>
 	/// <returns>The new constraint.</returns>
-	public static SelectionCountConstraint MaxSelected(IEnumerable<object> nodes, int maximum) => new(nodes, 0, maximum);
+	public static SelectionCountConstraint MaxSelected(ImmutableArray<object> nodes, int maximum) => new(nodes, 0, maximum);
+
+	/// <inheritdoc cref="MaxSelected(ImmutableArray{object}, int)"/>
+	public static SelectionCountConstraint MaxSelected(IEnumerable<object> nodes, int maximum) => MaxSelected(nodes.ToImmutableArray(), maximum);
 
 	/// <summary>
 	/// Creates a new constraint with the specified minimum for nodes that must be selected in the solution.
@@ -94,7 +98,10 @@ public class SelectionCountConstraint : IConstraint<bool>
 	/// <param name="nodes">The nodes that the constraint applies to.</param>
 	/// <param name="minimum">The minimum nodes that must be selected in the solution.</param>
 	/// <returns>The new constraint.</returns>
-	public static SelectionCountConstraint MinSelected(IEnumerable<object> nodes, int minimum) => new(nodes, minimum, int.MaxValue);
+	public static SelectionCountConstraint MinSelected(ImmutableArray<object> nodes, int minimum) => new(nodes, minimum, int.MaxValue);
+
+	/// <inheritdoc cref="MinSelected(ImmutableArray{object}, int)"/>
+	public static SelectionCountConstraint MinSelected(IEnumerable<object> nodes, int minimum) => MinSelected(nodes.ToImmutableArray(), minimum);
 
 	/// <summary>
 	/// Creates a new constraint with the specified number of nodes that must be selected in the solution.
@@ -102,7 +109,10 @@ public class SelectionCountConstraint : IConstraint<bool>
 	/// <param name="nodes">The nodes that the constraint applies to.</param>
 	/// <param name="selectedCount">The number of nodes that must be selected in the solution.</param>
 	/// <returns>The new constraint.</returns>
-	public static SelectionCountConstraint ExactSelected(IEnumerable<object> nodes, int selectedCount) => new(nodes, selectedCount, selectedCount);
+	public static SelectionCountConstraint ExactSelected(ImmutableArray<object> nodes, int selectedCount) => new(nodes, selectedCount, selectedCount);
+
+	/// <inheritdoc cref="ExactSelected(ImmutableArray{object}, int)"/>
+	public static SelectionCountConstraint ExactSelected(IEnumerable<object> nodes, int selectedCount) => ExactSelected(nodes.ToImmutableArray(), selectedCount);
 
 	/// <summary>
 	/// Creates a new constraint with the specified minimum and maximum for nodes that must be selected in the solution.
@@ -111,7 +121,10 @@ public class SelectionCountConstraint : IConstraint<bool>
 	/// <param name="minimum">The minimum nodes that must be selected in the solution.</param>
 	/// <param name="maximum">The maximum nodes that must be selected in the solution.</param>
 	/// <returns>The new constraint.</returns>
-	public static SelectionCountConstraint RangeSelected(IEnumerable<object> nodes, int minimum, int maximum) => new(nodes, minimum, maximum);
+	public static SelectionCountConstraint RangeSelected(ImmutableArray<object> nodes, int minimum, int maximum) => new(nodes, minimum, maximum);
+
+	/// <inheritdoc cref="RangeSelected(ImmutableArray{object}, int, int)"/>
+	public static SelectionCountConstraint RangeSelected(IEnumerable<object> nodes, int minimum, int maximum) => RangeSelected(nodes.ToImmutableArray(), minimum, maximum);
 
 	/// <inheritdoc/>
 	public override string ToString() => $"{this.GetType().Name}({this.Minimum}-{this.Maximum} from {{{string.Join(", ", this.Nodes)}}})";
@@ -183,7 +196,7 @@ public class SelectionCountConstraint : IConstraint<bool>
 	}
 
 	/// <inheritdoc/>
-	public bool Equals(IConstraint<bool>? other) => other is SelectionCountConstraint scc && this.Maximum == scc.Maximum && this.Minimum == scc.Minimum && this.Nodes.Count == scc.Nodes.Count && this.Nodes.SequenceEqual(scc.Nodes);
+	public bool Equals(IConstraint<bool>? other) => other is SelectionCountConstraint scc && this.Maximum == scc.Maximum && this.Minimum == scc.Minimum && this.Nodes.Length == scc.Nodes.Length && this.Nodes.SequenceEqual(scc.Nodes);
 
 	/// <summary>
 	/// Gets a value indicating whether we have so many UNselected nodes that the remaining nodes equal the minimum allowed selected nodes
@@ -191,7 +204,7 @@ public class SelectionCountConstraint : IConstraint<bool>
 	/// </summary>
 	/// <param name="stats">The node stats.</param>
 	/// <returns><see langword="true"/> if we can resolve by selecting the indeterminate nodes; <see langword="false"/> otherwise.</returns>
-	private bool CanResolveBySelecting(in NodeStats stats) => stats.Unselected == this.Nodes.Count - this.Minimum;
+	private bool CanResolveBySelecting(in NodeStats stats) => stats.Unselected == this.Nodes.Length - this.Minimum;
 
 	/// <summary>
 	/// Gets a value indicating whether the selected nodes equal the max allowable

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/SetOneNodeValueConstraint`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/SetOneNodeValueConstraint`1.cs
@@ -35,7 +35,7 @@ public class SetOneNodeValueConstraint<TNodeState> : IConstraint<TNodeState>
 	}
 
 	/// <inheritdoc/>
-	public IReadOnlyCollection<object> Nodes { get; }
+	public ImmutableArray<object> Nodes { get; }
 
 	/// <inheritdoc/>
 	public ConstraintStates GetState(Scenario<TNodeState> scenario)

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/SetOneNodeValueConstraint`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/SetOneNodeValueConstraint`1.cs
@@ -13,12 +13,7 @@ public class SetOneNodeValueConstraint<TNodeState> : IConstraint<TNodeState>
 	where TNodeState : unmanaged, IEquatable<TNodeState>
 {
 	/// <summary>
-	/// The node whose <see cref="value"/> is to be set.
-	/// </summary>
-	private readonly object node;
-
-	/// <summary>
-	/// The value to set the <see cref="node"/> to.
+	/// The value to set the <see cref="Node"/> to.
 	/// </summary>
 	private readonly TNodeState value;
 
@@ -29,10 +24,14 @@ public class SetOneNodeValueConstraint<TNodeState> : IConstraint<TNodeState>
 	/// <param name="value">The value to set the node to.</param>
 	public SetOneNodeValueConstraint(object node, TNodeState value)
 	{
-		this.node = node ?? throw new ArgumentNullException(nameof(node));
 		this.value = value;
-		this.Nodes = ImmutableArray.Create(node);
+		this.Nodes = ImmutableArray.Create(node ?? throw new ArgumentNullException(nameof(node)));
 	}
+
+	/// <summary>
+	/// Gets the one node impacted by this constraint.
+	/// </summary>
+	public object Node => this.Nodes[0];
 
 	/// <inheritdoc/>
 	public ImmutableArray<object> Nodes { get; }
@@ -45,7 +44,7 @@ public class SetOneNodeValueConstraint<TNodeState> : IConstraint<TNodeState>
 			throw new ArgumentNullException(nameof(scenario));
 		}
 
-		TNodeState? state = scenario[this.node];
+		TNodeState? state = scenario[this.Node];
 		if (state is null)
 		{
 			return ConstraintStates.Resolvable | ConstraintStates.Breakable | ConstraintStates.Satisfiable;
@@ -68,9 +67,9 @@ public class SetOneNodeValueConstraint<TNodeState> : IConstraint<TNodeState>
 			throw new ArgumentNullException(nameof(scenario));
 		}
 
-		if (scenario[this.node] is null)
+		if (scenario[this.Node] is null)
 		{
-			scenario[this.node] = this.value;
+			scenario[this.Node] = this.value;
 			return true;
 		}
 
@@ -78,8 +77,8 @@ public class SetOneNodeValueConstraint<TNodeState> : IConstraint<TNodeState>
 	}
 
 	/// <inheritdoc/>
-	public override string ToString() => $"{this.GetType().Name}(Set {{{this.node}}} to {this.value})";
+	public override string ToString() => $"{this.GetType().Name}(Set {{{this.Node}}} to {this.value})";
 
 	/// <inheritdoc/>
-	public bool Equals(IConstraint<TNodeState>? other) => other is SetOneNodeValueConstraint<TNodeState> sonv && this.node == sonv.node && this.value.Equals(sonv.value);
+	public bool Equals(IConstraint<TNodeState>? other) => other is SetOneNodeValueConstraint<TNodeState> sonv && this.Node == sonv.Node && this.value.Equals(sonv.value);
 }

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1+SolutionsAnalysis.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1+SolutionsAnalysis.cs
@@ -19,12 +19,14 @@ public partial class SolutionBuilder<TNodeState>
 		/// Initializes a new instance of the <see cref="SolutionsAnalysis"/> class.
 		/// </summary>
 		/// <param name="configuration">The problem space configuration.</param>
+		/// <param name="basisScenarioVersion">The value of <see cref="Scenario{TNodeState}.Version"/> from the <see cref="SolutionBuilder{TNodeState}"/> when the analysis began.</param>
 		/// <param name="viableSolutionsFound">The number of viable solutions that exist.</param>
 		/// <param name="nodeValueCount">The number of times each value was used for a given node in any viable solution.</param>
 		/// <param name="conflicts">Information about the conflicting constraints that prevent any viable solution from being found.</param>
-		internal SolutionsAnalysis(Configuration<TNodeState> configuration, long viableSolutionsFound, Dictionary<TNodeState, long>?[]? nodeValueCount, SolutionBuilder<TNodeState>.ConflictedConstraints? conflicts)
+		internal SolutionsAnalysis(Configuration<TNodeState> configuration, int basisScenarioVersion, long viableSolutionsFound, Dictionary<TNodeState, long>?[]? nodeValueCount, SolutionBuilder<TNodeState>.ConflictedConstraints? conflicts)
 		{
 			this.configuration = configuration;
+			this.BasisScenarioVersion = basisScenarioVersion;
 			this.ViableSolutionsFound = viableSolutionsFound;
 			this.NodeValueCount = nodeValueCount;
 			this.Conflicts = conflicts;
@@ -45,6 +47,11 @@ public partial class SolutionBuilder<TNodeState>
 		/// Gets the count that each state appears in a viable solution for each node.
 		/// </summary>
 		internal Dictionary<TNodeState, long>?[]? NodeValueCount { get; }
+
+		/// <summary>
+		/// Gets the value of <see cref="Scenario{TNodeState}.Version"/> from the <see cref="SolutionBuilder{TNodeState}"/> when the analysis began.
+		/// </summary>
+		internal int BasisScenarioVersion { get; }
 
 		/// <summary>
 		/// Gets the number of solutions in which a given node had a given value.

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1+SolutionsAnalysis.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1+SolutionsAnalysis.cs
@@ -13,25 +13,20 @@ public partial class SolutionBuilder<TNodeState>
 	/// </summary>
 	public class SolutionsAnalysis
 	{
-		private readonly SolutionBuilder<TNodeState> owner;
-
-		/// <summary>
-		/// The count that each state appears in a viable solution for each node.
-		/// </summary>
-		private readonly Dictionary<TNodeState, long>?[]? nodeValueCount;
+		private readonly Configuration<TNodeState> configuration;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SolutionsAnalysis"/> class.
 		/// </summary>
-		/// <param name="owner">The <see cref="SolutionBuilder{T}"/> that created this instance.</param>
+		/// <param name="configuration">The problem space configuration.</param>
 		/// <param name="viableSolutionsFound">The number of viable solutions that exist.</param>
 		/// <param name="nodeValueCount">The number of times each value was used for a given node in any viable solution.</param>
 		/// <param name="conflicts">Information about the conflicting constraints that prevent any viable solution from being found.</param>
-		internal SolutionsAnalysis(SolutionBuilder<TNodeState> owner, long viableSolutionsFound, Dictionary<TNodeState, long>?[]? nodeValueCount, SolutionBuilder<TNodeState>.ConflictedConstraints? conflicts)
+		internal SolutionsAnalysis(Configuration<TNodeState> configuration, long viableSolutionsFound, Dictionary<TNodeState, long>?[]? nodeValueCount, SolutionBuilder<TNodeState>.ConflictedConstraints? conflicts)
 		{
-			this.owner = owner;
+			this.configuration = configuration;
 			this.ViableSolutionsFound = viableSolutionsFound;
-			this.nodeValueCount = nodeValueCount;
+			this.NodeValueCount = nodeValueCount;
 			this.Conflicts = conflicts;
 		}
 
@@ -47,6 +42,11 @@ public partial class SolutionBuilder<TNodeState>
 		public SolutionBuilder<TNodeState>.ConflictedConstraints? Conflicts { get; }
 
 		/// <summary>
+		/// Gets the count that each state appears in a viable solution for each node.
+		/// </summary>
+		internal Dictionary<TNodeState, long>?[]? NodeValueCount { get; }
+
+		/// <summary>
 		/// Gets the number of solutions in which a given node had a given value.
 		/// </summary>
 		/// <param name="nodeIndex">The index of the node of interest.</param>
@@ -58,7 +58,7 @@ public partial class SolutionBuilder<TNodeState>
 		/// <exception cref="IndexOutOfRangeException">Thrown if <paramref name="nodeIndex"/> is negative or exceeds the number of nodes in the solution.</exception>
 		public long GetNodeValueCount(int nodeIndex, TNodeState value)
 		{
-			if (this.nodeValueCount is { } valueAndCounts)
+			if (this.NodeValueCount is { } valueAndCounts)
 			{
 				if (valueAndCounts[nodeIndex] is { } counts)
 				{
@@ -86,42 +86,6 @@ public partial class SolutionBuilder<TNodeState>
 		/// May be -1 if the <paramref name="node"/> is not constrained by anything and therefore can be anything in any solution.
 		/// </returns>
 		/// <exception cref="KeyNotFoundException">Thrown if the <paramref name="node"/> is not among the nodes in the solution.</exception>
-		public long GetNodeValueCount(object node, TNodeState value) => this.GetNodeValueCount(this.owner.CurrentScenario.GetNodeIndex(node), value);
-
-		/// <summary>
-		/// Select or unselect any indeterminate nodes which are unconditionally in just one state in all viable solutions.
-		/// </summary>
-		/// <remarks>
-		/// Constraints can interact as they narrow the field of viable solutions such that
-		/// some nodes may be effectively constrained to a certain value even though that value
-		/// isn't explicitly required by any individual constraint.
-		/// When these interactions are understood, applying them back to the <see cref="SolutionBuilder{T}"/>
-		/// can speed up future analyses and lead each node's value to reflect the remaining possibilities.
-		/// </remarks>
-		public void ApplyAnalysisBackToBuilder()
-		{
-			if (this.ViableSolutionsFound == 0 || this.nodeValueCount is null)
-			{
-				throw new InvalidOperationException(Strings.ViableSolutionStatsNotAvailable);
-			}
-
-			if (this.ViableSolutionsFound > 0)
-			{
-				for (int i = 0; i < this.nodeValueCount.Length; i++)
-				{
-					if (this.owner.CurrentScenario[i] is null && this.nodeValueCount[i] is { } valuesAndCounts)
-					{
-						foreach (TNodeState value in this.owner.resolvedNodeStates)
-						{
-							if (valuesAndCounts.TryGetValue(value, out long counts) && counts == this.ViableSolutionsFound)
-							{
-								this.owner.CurrentScenario[i] = value;
-								break;
-							}
-						}
-					}
-				}
-			}
-		}
+		public long GetNodeValueCount(object node, TNodeState value) => this.GetNodeValueCount(this.configuration.Index[node], value);
 	}
 }

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 
 namespace Nerdbank.Algorithms.NodeConstraintSelection;
 
@@ -23,7 +24,7 @@ public partial class SolutionBuilder<TNodeState>
 	/// <summary>
 	/// A map of nodes to their index as they appear in an ordered list.
 	/// </summary>
-	private readonly IReadOnlyDictionary<object, int> nodeIndex;
+	private readonly ReadOnlyDictionary<object, int> nodeIndex;
 
 	/// <summary>
 	/// An array of allowed values for each node.

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/SolutionBuilder`1.cs
@@ -44,14 +44,14 @@ public partial class SolutionBuilder<TNodeState>
 	/// <param name="resolvedNodeStates">An array of allowed values for each node.</param>
 	/// <exception cref="ArgumentNullException">Thrown if <paramref name="nodes"/> is <see langword="null"/>.</exception>
 	/// <exception cref="ArgumentException">Thrown if <paramref name="nodes"/> is empty or contains duplicates.</exception>
-	public SolutionBuilder(IReadOnlyList<object> nodes, ImmutableArray<TNodeState> resolvedNodeStates)
+	public SolutionBuilder(ImmutableArray<object> nodes, ImmutableArray<TNodeState> resolvedNodeStates)
 	{
-		if (nodes is null)
+		if (nodes.IsDefault)
 		{
 			throw new ArgumentNullException(nameof(nodes));
 		}
 
-		if (nodes.Count == 0)
+		if (nodes.IsEmpty)
 		{
 			throw new ArgumentException(Strings.NonEmptyArrayRequired, nameof(nodes));
 		}

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/Strings.Designer.cs
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/Strings.Designer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Nerdbank.Algorithms.NodeConstraintSelection; 
+namespace Nerdbank.Algorithms.NodeConstraintSelection {
     using System;
     
     
@@ -19,7 +19,7 @@ namespace Nerdbank.Algorithms.NodeConstraintSelection;
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Strings {
@@ -57,6 +57,15 @@ namespace Nerdbank.Algorithms.NodeConstraintSelection;
             }
             set {
                 resourceCulture = value;
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The solution has changed since this analysis was begun..
+        /// </summary>
+        internal static string AnalysisIsOutOfDate {
+            get {
+                return ResourceManager.GetString("AnalysisIsOutOfDate", resourceCulture);
             }
         }
         
@@ -276,3 +285,4 @@ namespace Nerdbank.Algorithms.NodeConstraintSelection;
             }
         }
     }
+}

--- a/src/Nerdbank.Algorithms/NodeConstraintSelection/Strings.resx
+++ b/src/Nerdbank.Algorithms/NodeConstraintSelection/Strings.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="AnalysisIsOutOfDate" xml:space="preserve">
+    <value>The solution has changed since this analysis was begun.</value>
+  </data>
   <data name="Arg1GreaterThanArg2Required" xml:space="preserve">
     <value>{0} must be greater than {1}.</value>
   </data>

--- a/src/Nerdbank.Algorithms/PublicAPI.Shipped.txt
+++ b/src/Nerdbank.Algorithms/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
@@ -9,6 +9,11 @@ Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConf
 Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConflictException(string! message) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConflictException(string! message, System.Exception! inner) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConflictException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.Configuration<TNodeState>
+Nerdbank.Algorithms.NodeConstraintSelection.Configuration<TNodeState>.Configuration(System.Collections.Immutable.ImmutableArray<object!> nodes, System.Collections.Immutable.ImmutableArray<TNodeState> resolvedNodeStates) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.Configuration<TNodeState>.Index.get -> System.Collections.ObjectModel.ReadOnlyDictionary<object!, int>!
+Nerdbank.Algorithms.NodeConstraintSelection.Configuration<TNodeState>.Nodes.get -> System.Collections.Immutable.ImmutableArray<object!>
+Nerdbank.Algorithms.NodeConstraintSelection.Configuration<TNodeState>.ResolvedNodeStates.get -> System.Collections.Immutable.ImmutableArray<TNodeState>
 Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
 Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.Breakable = 16 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
 Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.None = 0 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
@@ -24,7 +29,7 @@ Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>
 Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.GetNodeIndex(object! node) -> int
 Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.NodeCount.get -> int
 Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.NodeStates.get -> System.Collections.Generic.IReadOnlyList<TNodeState?>!
-Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.Scenario(System.Collections.Immutable.ImmutableArray<object!> nodes) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.Scenario(Nerdbank.Algorithms.NodeConstraintSelection.Configuration<TNodeState>! configuration) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.this[int index].get -> TNodeState?
 Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.this[int index].set -> void
 Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.this[object! node].get -> TNodeState?
@@ -48,8 +53,10 @@ Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.AddConstraint(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.AddConstraints(System.Collections.Generic.IEnumerable<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>! constraints) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.AnalyzeSolutions(System.Threading.CancellationToken cancellationToken) -> Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis!
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.AnalyzeSolutionsAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis!>!
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.CheckConstraint(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint, System.Threading.CancellationToken cancellationToken) -> bool
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.CheckForConflictingConstraints(System.Threading.CancellationToken cancellationToken) -> Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints?
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.CommitAnalysis(Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis! analysis) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints.GetConflictingConstraints(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IReadOnlyCollection<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>!
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.Constraints.get -> System.Collections.Generic.IReadOnlyCollection<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>!
@@ -57,9 +64,9 @@ Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.GetProba
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.RemoveConstraint(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.RemoveConstraints(System.Collections.Generic.IEnumerable<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>! constraints) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ResolvePartially(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionBuilder(Nerdbank.Algorithms.NodeConstraintSelection.Configuration<TNodeState>! configuration) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionBuilder(System.Collections.Immutable.ImmutableArray<object!> nodes, System.Collections.Immutable.ImmutableArray<TNodeState> resolvedNodeStates) -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis
-Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.ApplyAnalysisBackToBuilder() -> void
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.Conflicts.get -> Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints?
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.GetNodeValueCount(int nodeIndex, TNodeState value) -> long
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.GetNodeValueCount(object! node, TNodeState value) -> long

--- a/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
@@ -73,6 +73,7 @@ Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.Solution
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.ViableSolutionsFound.get -> long
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.this[int index].get -> TNodeState?
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.this[object! node].get -> TNodeState?
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.TryCommitAnalysis(Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis! analysis) -> bool
 Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilderExtensions
 override Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
 override Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.ToString() -> string!

--- a/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
@@ -1,0 +1,80 @@
+Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>
+Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>.BadConstraintException(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>.BadConstraintException(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint, string! message) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>.BadConstraintException(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint, string! message, System.Exception! inner) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>.BadConstraintException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>.Constraint.get -> Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!
+Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException
+Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConflictException() -> void
+Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConflictException(string! message) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConflictException(string! message, System.Exception! inner) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.ComplexConflictException.ComplexConflictException(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.Breakable = 16 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.None = 0 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.Resolvable = 4 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.Resolved = 8 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.Satisfiable = 1 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates.Satisfied = 3 -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>
+Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>.GetState(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>! scenario) -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>.Nodes.get -> System.Collections.Immutable.ImmutableArray<object!>
+Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>.Resolve(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>! scenario) -> bool
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.GetNodeIndex(object! node) -> int
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.NodeCount.get -> int
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.NodeStates.get -> System.Collections.Generic.IReadOnlyList<TNodeState?>!
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.Scenario(System.Collections.Immutable.ImmutableArray<object!> nodes) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.this[int index].get -> TNodeState?
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.this[int index].set -> void
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.this[object! node].get -> TNodeState?
+Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>.this[object! node].set -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.Equals(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<bool>? other) -> bool
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.GetState(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<bool>! scenario) -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.Maximum.get -> int
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.Minimum.get -> int
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.Nodes.get -> System.Collections.Immutable.ImmutableArray<object!>
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.Resolve(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<bool>! scenario) -> bool
+Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.SelectionCountConstraint(System.Collections.Immutable.ImmutableArray<object!> nodes, int minSelected, int maxSelected) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>
+Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.Equals(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>? other) -> bool
+Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.GetState(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>! scenario) -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.Nodes.get -> System.Collections.Immutable.ImmutableArray<object!>
+Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.Resolve(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>! scenario) -> bool
+Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.SetOneNodeValueConstraint(object! node, TNodeState value) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.AddConstraint(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.AddConstraints(System.Collections.Generic.IEnumerable<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>! constraints) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.AnalyzeSolutions(System.Threading.CancellationToken cancellationToken) -> Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis!
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.CheckConstraint(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint, System.Threading.CancellationToken cancellationToken) -> bool
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.CheckForConflictingConstraints(System.Threading.CancellationToken cancellationToken) -> Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints?
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints.GetConflictingConstraints(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IReadOnlyCollection<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>!
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.Constraints.get -> System.Collections.Generic.IReadOnlyCollection<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>!
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.GetProbableSolution(System.Threading.CancellationToken cancellationToken) -> Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>!
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.RemoveConstraint(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>! constraint) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.RemoveConstraints(System.Collections.Generic.IEnumerable<Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!>! constraints) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ResolvePartially(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionBuilder(System.Collections.Immutable.ImmutableArray<object!> nodes, System.Collections.Immutable.ImmutableArray<TNodeState> resolvedNodeStates) -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.ApplyAnalysisBackToBuilder() -> void
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.Conflicts.get -> Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.ConflictedConstraints?
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.GetNodeValueCount(int nodeIndex, TNodeState value) -> long
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.GetNodeValueCount(object! node, TNodeState value) -> long
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.SolutionsAnalysis.ViableSolutionsFound.get -> long
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.this[int index].get -> TNodeState?
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>.this[object! node].get -> TNodeState?
+Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilderExtensions
+override Nerdbank.Algorithms.NodeConstraintSelection.BadConstraintException<TNodeState>.GetObjectData(System.Runtime.Serialization.SerializationInfo! info, System.Runtime.Serialization.StreamingContext context) -> void
+override Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.ToString() -> string!
+override Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.ToString() -> string!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.ExactSelected(System.Collections.Generic.IEnumerable<object!>! nodes, int selectedCount) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.ExactSelected(System.Collections.Immutable.ImmutableArray<object!> nodes, int selectedCount) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.MaxSelected(System.Collections.Generic.IEnumerable<object!>! nodes, int maximum) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.MaxSelected(System.Collections.Immutable.ImmutableArray<object!> nodes, int maximum) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.MinSelected(System.Collections.Generic.IEnumerable<object!>! nodes, int minimum) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.MinSelected(System.Collections.Immutable.ImmutableArray<object!> nodes, int minimum) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.RangeSelected(System.Collections.Generic.IEnumerable<object!>! nodes, int minimum, int maximum) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.RangeSelected(System.Collections.Immutable.ImmutableArray<object!> nodes, int minimum, int maximum) -> Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint!
+static Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilderExtensions.SetNodeState<TNodeState>(this Nerdbank.Algorithms.NodeConstraintSelection.SolutionBuilder<TNodeState>! builder, object! node, TNodeState value) -> Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>!

--- a/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Algorithms/PublicAPI.Unshipped.txt
@@ -40,6 +40,7 @@ Nerdbank.Algorithms.NodeConstraintSelection.SelectionCountConstraint.SelectionCo
 Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>
 Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.Equals(Nerdbank.Algorithms.NodeConstraintSelection.IConstraint<TNodeState>? other) -> bool
 Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.GetState(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>! scenario) -> Nerdbank.Algorithms.NodeConstraintSelection.ConstraintStates
+Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.Node.get -> object!
 Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.Nodes.get -> System.Collections.Immutable.ImmutableArray<object!>
 Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.Resolve(Nerdbank.Algorithms.NodeConstraintSelection.Scenario<TNodeState>! scenario) -> bool
 Nerdbank.Algorithms.NodeConstraintSelection.SetOneNodeValueConstraint<TNodeState>.SetOneNodeValueConstraint(object! node, TNodeState value) -> void

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/ClueScenarioTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/ClueScenarioTests.cs
@@ -39,28 +39,29 @@ public class ClueScenarioTests : TestBase
 		void CreateNodesForCategory(ImmutableArray<Card> cards)
 		{
 			// Start by creating the nodes for the case file.
-			var caseFileNodes = new List<object>();
+			ImmutableArray<object>.Builder caseFileNodesBuilder = ImmutableArray.CreateBuilder<object>(cards.Length);
 			foreach (Card card in cards)
 			{
-				var allHolderNodes = new List<object>();
+				ImmutableArray<object>.Builder allHolderNodesBuilder = ImmutableArray.CreateBuilder<object>(Players.Length + 1);
 				foreach (CardHolder player in Players)
 				{
 					object node = (card, player);
 					cardsPerPlayer[player].Add(node);
-					allHolderNodes.Add(node);
+					allHolderNodesBuilder.Add(node);
 				}
 
 				object caseFileNode = (card, CaseFile);
-				allHolderNodes.Add(caseFileNode);
-				caseFileNodes.Add(caseFileNode);
+				allHolderNodesBuilder.Add(caseFileNode);
+				caseFileNodesBuilder.Add(caseFileNode);
 
 				// This card can only appear in one place: a player or the case file.
+				ImmutableArray<object> allHolderNodes = allHolderNodesBuilder.MoveToImmutable();
 				constraints.Add(SelectionCountConstraint.ExactSelected(allHolderNodes, 1));
 				nodes.AddRange(allHolderNodes);
 			}
 
 			// Exactly one card from this whole category of cards will appear in the case file.
-			constraints.Add(SelectionCountConstraint.ExactSelected(caseFileNodes, 1));
+			constraints.Add(SelectionCountConstraint.ExactSelected(caseFileNodesBuilder.MoveToImmutable(), 1));
 		}
 
 		CreateNodesForCategory(Suspects);

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SelectionCountConstraintTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SelectionCountConstraintTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 public class SelectionCountConstraintTests
 {
-	private ImmutableArray<DummyNode> nodes;
+	private ImmutableArray<object> nodes;
 	private Scenario<bool> scenario;
 
 	/// <summary>
@@ -15,8 +15,8 @@ public class SelectionCountConstraintTests
 	/// </summary>
 	public SelectionCountConstraintTests()
 	{
-		this.nodes = ImmutableArray.Create(new DummyNode("a"), new DummyNode("b"), new DummyNode("c"), new DummyNode("d"));
-		this.scenario = new Scenario<bool>(this.nodes);
+		this.nodes = ImmutableArray.Create<object>(new DummyNode("a"), new DummyNode("b"), new DummyNode("c"), new DummyNode("d"));
+		this.scenario = new Scenario<bool>(this.nodes.As<object>());
 	}
 
 	[Fact]
@@ -288,7 +288,7 @@ public class SelectionCountConstraintTests
 	{
 		// If exactly one node should be selected and one node is in the list,
 		// then it should be selected by resolving.
-		DummyNode[] shortList = this.nodes.Take(1).ToArray();
+		ImmutableArray<object> shortList = ImmutableArray.Create(this.nodes[0]);
 		var target = SelectionCountConstraint.ExactSelected(shortList, 1);
 		Assert.True(target.GetState(this.scenario).HasFlag(ConstraintStates.Resolvable));
 		Assert.True(target.Resolve(this.scenario));

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SelectionCountConstraintTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SelectionCountConstraintTests.cs
@@ -16,7 +16,7 @@ public class SelectionCountConstraintTests
 	public SelectionCountConstraintTests()
 	{
 		this.nodes = ImmutableArray.Create<object>(new DummyNode("a"), new DummyNode("b"), new DummyNode("c"), new DummyNode("d"));
-		this.scenario = new Scenario<bool>(this.nodes.As<object>());
+		this.scenario = new Scenario<bool>(new Configuration<bool>(this.nodes.As<object>(), ImmutableArray.Create(true, false)));
 	}
 
 	[Fact]

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SetOneNodeValueConstraintTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SetOneNodeValueConstraintTests.cs
@@ -23,7 +23,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void Resolve_PreviouslyUnset()
 	{
 		var nodes = ImmutableArray.Create(new object());
-		var scenario = new Scenario<bool>(nodes);
+		var scenario = new Scenario<bool>(new Configuration<bool>(nodes, ImmutableArray.Create(true, false)));
 		Assert.True(new SetOneNodeValueConstraint<bool>(nodes[0], true).Resolve(scenario));
 		Assert.True(scenario[0]);
 	}
@@ -34,7 +34,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void Resolve_AlreadySet(bool matchingValue)
 	{
 		var nodes = ImmutableArray.Create(new object());
-		var scenario = new Scenario<bool>(nodes);
+		var scenario = new Scenario<bool>(new Configuration<bool>(nodes, ImmutableArray.Create(true, false)));
 		scenario[0] = matchingValue ? true : false;
 		Assert.False(new SetOneNodeValueConstraint<bool>(nodes[0], true).Resolve(scenario));
 	}
@@ -55,7 +55,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void GetState_Resolvable()
 	{
 		var nodes = ImmutableArray.Create("my node");
-		var scenario = new Scenario<bool>(nodes.As<object>());
+		var scenario = new Scenario<bool>(new Configuration<bool>(nodes.As<object>(), ImmutableArray.Create(true, false)));
 		var constraint = new SetOneNodeValueConstraint<bool>(nodes[0], true);
 		Assert.Equal(ConstraintStates.Resolvable | ConstraintStates.Satisfiable | ConstraintStates.Breakable, constraint.GetState(scenario));
 	}
@@ -64,7 +64,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void GetState_Resolved()
 	{
 		var nodes = ImmutableArray.Create("my node");
-		var scenario = new Scenario<bool>(nodes.As<object>());
+		var scenario = new Scenario<bool>(new Configuration<bool>(nodes.As<object>(), ImmutableArray.Create(true, false)));
 		var constraint = new SetOneNodeValueConstraint<bool>(nodes[0], true);
 		scenario[0] = true;
 		Assert.Equal(ConstraintStates.Resolved | ConstraintStates.Satisfied, constraint.GetState(scenario));
@@ -74,7 +74,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void GetState_Broken()
 	{
 		var nodes = ImmutableArray.Create("my node");
-		var scenario = new Scenario<bool>(nodes.As<object>());
+		var scenario = new Scenario<bool>(new Configuration<bool>(nodes.As<object>(), ImmutableArray.Create(true, false)));
 		var constraint = new SetOneNodeValueConstraint<bool>(nodes[0], true);
 		scenario[0] = false;
 		Assert.Equal(ConstraintStates.Resolved, constraint.GetState(scenario));

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SetOneNodeValueConstraintTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SetOneNodeValueConstraintTests.cs
@@ -55,7 +55,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void GetState_Resolvable()
 	{
 		var nodes = ImmutableArray.Create("my node");
-		var scenario = new Scenario<bool>(nodes);
+		var scenario = new Scenario<bool>(nodes.As<object>());
 		var constraint = new SetOneNodeValueConstraint<bool>(nodes[0], true);
 		Assert.Equal(ConstraintStates.Resolvable | ConstraintStates.Satisfiable | ConstraintStates.Breakable, constraint.GetState(scenario));
 	}
@@ -64,7 +64,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void GetState_Resolved()
 	{
 		var nodes = ImmutableArray.Create("my node");
-		var scenario = new Scenario<bool>(nodes);
+		var scenario = new Scenario<bool>(nodes.As<object>());
 		var constraint = new SetOneNodeValueConstraint<bool>(nodes[0], true);
 		scenario[0] = true;
 		Assert.Equal(ConstraintStates.Resolved | ConstraintStates.Satisfied, constraint.GetState(scenario));
@@ -74,7 +74,7 @@ public class SetOneNodeValueConstraintTests : TestBase
 	public void GetState_Broken()
 	{
 		var nodes = ImmutableArray.Create("my node");
-		var scenario = new Scenario<bool>(nodes);
+		var scenario = new Scenario<bool>(nodes.As<object>());
 		var constraint = new SetOneNodeValueConstraint<bool>(nodes[0], true);
 		scenario[0] = false;
 		Assert.Equal(ConstraintStates.Resolved, constraint.GetState(scenario));

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
@@ -473,6 +473,22 @@ public class SolutionBuilderTests : TestBase
 		this.builder.CommitAnalysis(analysis);
 	}
 
+	[Fact]
+	public async Task AnalyzeSolutionAsync_StaleAnalysisCannotBeCommittedBack()
+	{
+		this.builder.AddConstraints(new[]
+		{
+			SelectionCountConstraint.ExactSelected(Nodes.Take(3), 1),
+		});
+		SolutionBuilder<bool>.SolutionsAnalysis analysis = await this.builder.AnalyzeSolutionsAsync(this.TimeoutToken);
+		this.builder.AddConstraint(SelectionCountConstraint.ExactSelected(Nodes.Take(1), 1));
+
+		Assert.False(this.builder.TryCommitAnalysis(analysis));
+
+		InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => this.builder.CommitAnalysis(analysis));
+		this.Logger.WriteLine(ex.Message);
+	}
+
 	/// <summary>
 	/// Verifies that checking for conflicting constraints can quickly find a conflict even in a very large problem space.
 	/// </summary>

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
@@ -8,14 +8,14 @@ using Xunit.Abstractions;
 
 public class SolutionBuilderTests : TestBase
 {
-	private static readonly IReadOnlyList<DummyNode> Nodes = ImmutableList.Create(new DummyNode("a"), new DummyNode("b"), new DummyNode("c"), new DummyNode("d"));
+	private static readonly ImmutableArray<object> Nodes = ImmutableArray.Create<object>(new DummyNode("a"), new DummyNode("b"), new DummyNode("c"), new DummyNode("d"));
 
 	private readonly SolutionBuilder<bool> builder;
 
 	public SolutionBuilderTests(ITestOutputHelper logger)
 		: base(logger)
 	{
-		this.builder = new SolutionBuilder<bool>(Nodes, ImmutableArray.Create(true, false));
+		this.builder = new SolutionBuilder<bool>(Nodes.As<object>(), ImmutableArray.Create(true, false));
 	}
 
 	[Fact]
@@ -31,7 +31,7 @@ public class SolutionBuilderTests : TestBase
 	[Fact]
 	public void GetProbableSolution_MultipleStates()
 	{
-		var nodes = new object[] { 1, 2, 3 };
+		var nodes = ImmutableArray.Create<object>(1, 2, 3);
 		var builder = new SolutionBuilder<char>(nodes, ImmutableArray.Create('a', 'b', 'c', 'd'));
 		builder.AddConstraint(new NoAConstraint(nodes));
 		builder.AddConstraint(new NoDuplicatesConstraint(nodes));
@@ -47,33 +47,33 @@ public class SolutionBuilderTests : TestBase
 	[Fact]
 	public void Ctor_NullNodes()
 	{
-		Assert.Throws<ArgumentNullException>("nodes", () => new SolutionBuilder<bool>(default!, ImmutableArray.Create(true, false)));
+		Assert.Throws<ArgumentNullException>("nodes", () => new SolutionBuilder<bool>(default, ImmutableArray.Create(true, false)));
 	}
 
 	[Fact]
 	public void Ctor_UninitializedStates()
 	{
-		Assert.Throws<ArgumentException>("resolvedNodeStates", () => new SolutionBuilder<bool>(new[] { new DummyNode("a") }, default));
+		Assert.Throws<ArgumentException>("resolvedNodeStates", () => new SolutionBuilder<bool>(ImmutableArray.Create<object>(new DummyNode("a")), default));
 	}
 
 	[Fact]
 	public void Ctor_LessThanTwoStates()
 	{
-		Assert.Throws<ArgumentException>("resolvedNodeStates", () => new SolutionBuilder<bool>(new[] { new DummyNode("a") }, ImmutableArray<bool>.Empty));
-		Assert.Throws<ArgumentException>("resolvedNodeStates", () => new SolutionBuilder<bool>(new[] { new DummyNode("a") }, ImmutableArray.Create(true)));
+		Assert.Throws<ArgumentException>("resolvedNodeStates", () => new SolutionBuilder<bool>(ImmutableArray.Create<object>(new DummyNode("a")), ImmutableArray<bool>.Empty));
+		Assert.Throws<ArgumentException>("resolvedNodeStates", () => new SolutionBuilder<bool>(ImmutableArray.Create<object>(new DummyNode("a")), ImmutableArray.Create(true)));
 	}
 
 	[Fact]
 	public void Ctor_EmptyNodeList()
 	{
-		Assert.Throws<ArgumentException>("nodes", () => new SolutionBuilder<bool>(Array.Empty<DummyNode>(), ImmutableArray.Create(true, false)));
+		Assert.Throws<ArgumentException>("nodes", () => new SolutionBuilder<bool>(ImmutableArray.Create<object>(), ImmutableArray.Create(true, false)));
 	}
 
 	[Fact]
 	public void Ctor_NonUniqueNodes()
 	{
 		var n = new DummyNode("a");
-		Assert.Throws<ArgumentException>(() => new SolutionBuilder<bool>(new[] { n, n }, ImmutableArray.Create(true, false)));
+		Assert.Throws<ArgumentException>(() => new SolutionBuilder<bool>(ImmutableArray.Create<object>(n, n), ImmutableArray.Create(true, false)));
 	}
 
 	[Fact]
@@ -135,7 +135,7 @@ public class SolutionBuilderTests : TestBase
 		this.builder.ResolvePartially();
 		Assert.True(this.builder[0]);
 		Assert.True(this.builder[1]);
-		for (int i = 2; i < Nodes.Count; i++)
+		for (int i = 2; i < Nodes.Length; i++)
 		{
 			Assert.Null(this.builder[i]);
 		}
@@ -270,12 +270,12 @@ public class SolutionBuilderTests : TestBase
 
 		this.builder.ResolvePartially(this.TimeoutToken);
 		Assert.True(this.builder[0]);
-		for (int i = 1; i < Nodes.Count - 1; i++)
+		for (int i = 1; i < Nodes.Length - 1; i++)
 		{
 			Assert.False(this.builder[i]);
 		}
 
-		Assert.Null(this.builder[Nodes.Count - 1]);
+		Assert.Null(this.builder[Nodes.Length - 1]);
 	}
 
 	[Fact]
@@ -312,7 +312,7 @@ public class SolutionBuilderTests : TestBase
 
 		this.builder.ResolvePartially(this.TimeoutToken);
 		Assert.Null(this.builder.CheckForConflictingConstraints(this.TimeoutToken));
-		for (int i = 0; i < Nodes.Count; i++)
+		for (int i = 0; i < Nodes.Length; i++)
 		{
 			Assert.NotNull(this.builder[i]);
 		}
@@ -328,7 +328,7 @@ public class SolutionBuilderTests : TestBase
 			SelectionCountConstraint.ExactSelected(Nodes.Take(2), 1),
 			SelectionCountConstraint.ExactSelected(Nodes.Skip(2), 1),
 			SelectionCountConstraint.ExactSelected(Nodes, 1),
-			SelectionCountConstraint.RangeSelected(Nodes, 1, Nodes.Count),
+			SelectionCountConstraint.RangeSelected(Nodes, 1, Nodes.Length),
 		};
 		this.builder.AddConstraints(constraints);
 
@@ -380,7 +380,7 @@ public class SolutionBuilderTests : TestBase
 		Assert.Null(analysis.Conflicts);
 		Assert.Equal(1, analysis.ViableSolutionsFound);
 
-		for (int i = 0; i < Nodes.Count; i++)
+		for (int i = 0; i < Nodes.Length; i++)
 		{
 			Assert.Equal(-1, analysis.GetNodeValueCount(0, true));
 			Assert.Equal(-1, analysis.GetNodeValueCount(Nodes[0], true));
@@ -390,14 +390,14 @@ public class SolutionBuilderTests : TestBase
 	[Fact]
 	public void AnalyzeSolution_WorthlessConstraint()
 	{
-		this.builder.AddConstraint(SelectionCountConstraint.RangeSelected(Nodes, 0, Nodes.Count));
+		this.builder.AddConstraint(SelectionCountConstraint.RangeSelected(Nodes, 0, Nodes.Length));
 		SolutionBuilder<bool>.SolutionsAnalysis analysis = this.builder.AnalyzeSolutions(this.TimeoutToken);
 		Assert.NotNull(analysis);
 
 		Assert.Null(analysis.Conflicts);
 		Assert.Equal(16, analysis.ViableSolutionsFound);
 
-		for (int i = 0; i < Nodes.Count; i++)
+		for (int i = 0; i < Nodes.Length; i++)
 		{
 			Assert.Equal(analysis.ViableSolutionsFound / 2, analysis.GetNodeValueCount(0, true));
 		}
@@ -435,12 +435,12 @@ public class SolutionBuilderTests : TestBase
 		// Verify that applying the analysis results back to the builder
 		// lead to 010x results.
 		analysis.ApplyAnalysisBackToBuilder();
-		for (int i = 0; i < Nodes.Count - 1; i++)
+		for (int i = 0; i < Nodes.Length - 1; i++)
 		{
 			Assert.Equal(i == 1, this.builder[i]);
 		}
 
-		Assert.Null(this.builder[Nodes.Count - 1]);
+		Assert.Null(this.builder[Nodes.Length - 1]);
 
 		SolutionBuilder<bool>.SolutionsAnalysis analysis2 = this.builder.AnalyzeSolutions(this.TimeoutToken);
 		Assert.Equal(analysis.ViableSolutionsFound, analysis2.ViableSolutionsFound);
@@ -487,8 +487,8 @@ public class SolutionBuilderTests : TestBase
 
 	private static SolutionBuilder<bool> CreateBuilderWithNonObviousConflictInVeryLargeProblemSpace()
 	{
-		DummyNode[] nodes = Enumerable.Range(1, 100).Select(n => new DummyNode(n)).ToArray();
-		var builder = new SolutionBuilder<bool>(nodes, ImmutableArray.Create(true, false));
+		ImmutableArray<DummyNode> nodes = Enumerable.Range(1, 100).Select(n => new DummyNode(n)).ToImmutableArray();
+		var builder = new SolutionBuilder<bool>(nodes.As<object>(), ImmutableArray.Create(true, false));
 		builder.AddConstraints(new[]
 		{
 			SelectionCountConstraint.ExactSelected(nodes.Skip(90).Take(3), 1),
@@ -499,7 +499,7 @@ public class SolutionBuilderTests : TestBase
 
 	private void AssertAllNodesIndeterminate()
 	{
-		for (int i = 0; i < Nodes.Count; i++)
+		for (int i = 0; i < Nodes.Length; i++)
 		{
 			Assert.Null(this.builder[i]);
 		}
@@ -511,7 +511,7 @@ public class SolutionBuilderTests : TestBase
 	/// </summary>
 	private class FalselyNonResolvingConstraint : IConstraint<bool>
 	{
-		public IReadOnlyCollection<object> Nodes { get; } = SolutionBuilderTests.Nodes;
+		public ImmutableArray<object> Nodes { get; } = SolutionBuilderTests.Nodes;
 
 		public bool Equals(IConstraint<bool>? other)
 		{
@@ -531,7 +531,7 @@ public class SolutionBuilderTests : TestBase
 	/// </summary>
 	private class ThrowingConstraint : IConstraint<bool>
 	{
-		public IReadOnlyCollection<object> Nodes { get; } = SolutionBuilderTests.Nodes;
+		public ImmutableArray<object> Nodes { get; } = SolutionBuilderTests.Nodes;
 
 		public bool Equals(IConstraint<bool>? other)
 		{
@@ -551,7 +551,7 @@ public class SolutionBuilderTests : TestBase
 
 	private class EmptyNodeSetConstraint : IConstraint<bool>
 	{
-		public IReadOnlyCollection<object> Nodes => Array.Empty<object>();
+		public ImmutableArray<object> Nodes => ImmutableArray.Create<object>();
 
 		public bool Equals(IConstraint<bool>? other)
 		{
@@ -571,12 +571,12 @@ public class SolutionBuilderTests : TestBase
 
 	private class NoAConstraint : IConstraint<char>
 	{
-		internal NoAConstraint(object[] nodes)
+		internal NoAConstraint(ImmutableArray<object> nodes)
 		{
 			this.Nodes = nodes;
 		}
 
-		public IReadOnlyCollection<object> Nodes { get; }
+		public ImmutableArray<object> Nodes { get; }
 
 		public bool Equals(IConstraint<char>? other) => false;
 
@@ -614,12 +614,12 @@ public class SolutionBuilderTests : TestBase
 
 	private class NoDuplicatesConstraint : IConstraint<char>
 	{
-		internal NoDuplicatesConstraint(object[] nodes)
+		internal NoDuplicatesConstraint(ImmutableArray<object> nodes)
 		{
 			this.Nodes = nodes;
 		}
 
-		public IReadOnlyCollection<object> Nodes { get; }
+		public ImmutableArray<object> Nodes { get; }
 
 		public bool Equals(IConstraint<char>? other) => false;
 

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
@@ -205,7 +205,7 @@ public class SolutionBuilderTests : TestBase
 		Assert.Null(this.builder[2]);
 
 		// Analyze all viable solutions and apply back so that the deduced node state is set.
-		this.builder.AnalyzeSolutions(this.TimeoutToken).ApplyAnalysisBackToBuilder();
+		this.builder.CommitAnalysis(this.builder.AnalyzeSolutions(this.TimeoutToken));
 
 		// Verify that the deduced constraint was added.
 		Assert.False(this.builder[2]);
@@ -216,7 +216,7 @@ public class SolutionBuilderTests : TestBase
 		Assert.Null(this.builder[2]);
 
 		// Verify once again that the deduced node can no longer be deduced.
-		this.builder.AnalyzeSolutions(this.TimeoutToken).ApplyAnalysisBackToBuilder();
+		this.builder.CommitAnalysis(this.builder.AnalyzeSolutions(this.TimeoutToken));
 		Assert.Null(this.builder[2]);
 	}
 
@@ -434,7 +434,7 @@ public class SolutionBuilderTests : TestBase
 
 		// Verify that applying the analysis results back to the builder
 		// lead to 010x results.
-		analysis.ApplyAnalysisBackToBuilder();
+		this.builder.CommitAnalysis(analysis);
 		for (int i = 0; i < Nodes.Length - 1; i++)
 		{
 			Assert.Equal(i == 1, this.builder[i]);
@@ -459,7 +459,7 @@ public class SolutionBuilderTests : TestBase
 		Assert.Equal(0, analysis.ViableSolutionsFound);
 		Assert.NotNull(analysis.Conflicts);
 		Assert.Throws<InvalidOperationException>(() => analysis.GetNodeValueCount(0, true));
-		Assert.Throws<InvalidOperationException>(() => analysis.ApplyAnalysisBackToBuilder());
+		Assert.Throws<InvalidOperationException>(() => this.builder.CommitAnalysis(analysis));
 	}
 
 	/// <summary>

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SolutionBuilderTests.cs
@@ -462,6 +462,17 @@ public class SolutionBuilderTests : TestBase
 		Assert.Throws<InvalidOperationException>(() => this.builder.CommitAnalysis(analysis));
 	}
 
+	[Fact]
+	public async Task AnalyzeSolutionAsync_FreshAnalysisCanBeCommittedBack()
+	{
+		this.builder.AddConstraints(new[]
+		{
+			SelectionCountConstraint.ExactSelected(Nodes.Take(3), 1),
+		});
+		SolutionBuilder<bool>.SolutionsAnalysis analysis = await this.builder.AnalyzeSolutionsAsync(this.TimeoutToken);
+		this.builder.CommitAnalysis(analysis);
+	}
+
 	/// <summary>
 	/// Verifies that checking for conflicting constraints can quickly find a conflict even in a very large problem space.
 	/// </summary>

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SudokuScenarioTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SudokuScenarioTests.cs
@@ -19,7 +19,7 @@ public class SudokuScenarioTests : TestBase
 	public SudokuScenarioTests(ITestOutputHelper logger)
 		: base(logger)
 	{
-		this.builder = new SolutionBuilder<int>(NodeGrid.SelectMany(a => a).ToList(), PossibleCellValues);
+		this.builder = new SolutionBuilder<int>(NodeGrid.SelectMany(a => a).ToImmutableArray(), PossibleCellValues);
 
 		for (int row = 0; row < 9; row++)
 		{
@@ -38,7 +38,7 @@ public class SudokuScenarioTests : TestBase
 				IEnumerable<object> nodes = from c in Enumerable.Range(column, 3)
 											from r in Enumerable.Range(row, 3)
 											select NodeGrid[c][r];
-				this.builder.AddConstraint(new UniqueValueConstraint(nodes.ToList()));
+				this.builder.AddConstraint(new UniqueValueConstraint(nodes.ToImmutableArray()));
 			}
 		}
 	}
@@ -122,9 +122,9 @@ public class SudokuScenarioTests : TestBase
 	/// </summary>
 	private class UniqueValueConstraint : IConstraint<int>
 	{
-		internal UniqueValueConstraint(IReadOnlyCollection<object> nodes)
+		internal UniqueValueConstraint(ImmutableArray<object> nodes)
 		{
-			if (nodes.Count != 9)
+			if (nodes.Length != 9)
 			{
 				throw new ArgumentException("Always applied to 9 nodes.", nameof(nodes));
 			}
@@ -132,11 +132,11 @@ public class SudokuScenarioTests : TestBase
 			this.Nodes = nodes;
 		}
 
-		public IReadOnlyCollection<object> Nodes { get; }
+		public ImmutableArray<object> Nodes { get; }
 
 		public bool Equals(IConstraint<int>? other)
 		{
-			return other is UniqueValueConstraint uv && this.Nodes.Count == uv.Nodes.Count && this.Nodes.SequenceEqual(uv.Nodes);
+			return other is UniqueValueConstraint uv && this.Nodes.Length == uv.Nodes.Length && this.Nodes.SequenceEqual(uv.Nodes);
 		}
 
 		public ConstraintStates GetState(Scenario<int> scenario)
@@ -167,7 +167,7 @@ public class SudokuScenarioTests : TestBase
 					}
 				}
 
-				if (resolvedNodesCount == this.Nodes.Count)
+				if (resolvedNodesCount == this.Nodes.Length)
 				{
 					result |= ConstraintStates.Resolved;
 

--- a/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SudokuScenarioTests.cs
+++ b/test/Nerdbank.Algorithms.Tests/NodeConstraintSelection/SudokuScenarioTests.cs
@@ -94,7 +94,7 @@ public class SudokuScenarioTests : TestBase
 		Assert.Equal(1, analysis.ViableSolutionsFound);
 
 		this.Logger.WriteLine("Solution:");
-		analysis.ApplyAnalysisBackToBuilder();
+		this.builder.CommitAnalysis(analysis);
 		this.PrintGrid();
 	}
 

--- a/version.json
+++ b/version.json
@@ -1,8 +1,11 @@
 {
-  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.2-beta",
-  "publicReleaseRefSpec": [
-    "^refs/heads/master$", // we release out of master
-    "^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches
-  ]
+	"$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+	"version": "3.0-alpha",
+	"publicReleaseRefSpec": [
+		"^refs/heads/main$", // we release out of master
+		"^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches
+	],
+	"cloudBuild": {
+		"setVersionVariables": false
+	}
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.1",
+  "version": "2.2-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/v\\d+(?:\\.\\d+)?$" // we also release out of vNN branches


### PR DESCRIPTION
A bunch of refactoring changes to ensure that only immutable shared state (or mutable private state) is accessible from background analysis paths. This guarantees safety when calling the new `SolutionBuilder<TNodeState>.AnalyzeSolutionsAsync` method and allowing background work to proceed while calling other APIs in the foreground.